### PR TITLE
Make project info item more compact

### DIFF
--- a/colorful.css
+++ b/colorful.css
@@ -5663,8 +5663,8 @@ button.close {
 }
 
 .carousel-inner {
-  position: relative;
-  width: 100%;
+  width: 80%;
+  margin: 0 auto;
   overflow: hidden;
 }
 


### PR DESCRIPTION
The project logo doesn't overlap the pre icon now, at least on my machine.